### PR TITLE
Added "SetBroadcastAddress(net.IP)" function

### DIFF
--- a/lifx.go
+++ b/lifx.go
@@ -1,7 +1,9 @@
 package golifx
 
+import "net"
+
 var (
-	conn = &connection{}
+	conn = &connection{bcastAddress: net.IPv4bcast}
 )
 
 const (
@@ -71,4 +73,8 @@ func LookupBulbs() ([]*Bulb, error) {
 	}
 
 	return bulbs, nil
+}
+
+func SetBroadcastAddress(addr net.IP) {
+	conn.bcastAddress = addr
 }

--- a/net.go
+++ b/net.go
@@ -5,10 +5,9 @@ import (
 	"time"
 )
 
-type (
-	connection struct {
-	}
-)
+type connection struct {
+	bcastAddress net.IP
+}
 
 const (
 	_DEFAULT_MAX_DEAD_LINE = time.Millisecond * 500
@@ -40,7 +39,7 @@ func (c *connection) sendAndReceiveDead(inMessage *message, deadline time.Durati
 	}
 
 	_, err = conn.WriteTo(inMessage.ReadRaw(), &net.UDPAddr{
-		IP:   net.IPv4bcast,
+		IP:   c.bcastAddress,
 		Port: _DEFAULT_PORT,
 	})
 


### PR DESCRIPTION
When running a system with multiple interfaces the possibility to
change broadcast address is needed. 

For example on a unix machine: 
eth0 = internet
eth1 = lan.

If 255.255.255.255 is used as broadcast address the trafic will be sent
to the first interface, in this case eth0 (internet) and this lib will never find any bulbs.
