### PR TITLE
Adds public constants for Waveform types

### DIFF
--- a/lifx.go
+++ b/lifx.go
@@ -44,6 +44,14 @@ const (
 	_POWER_STATE_DURATION = 118
 )
 
+const (
+	WAVEFORM_SAW       uint8 = 0
+	WAVEFORM_SINE      uint8 = 1
+	WAVEFORM_HALF_SINE uint8 = 2
+	WAVEFORM_TRIANGLE  uint8 = 3
+	WAVEFORM_PULSE     uint8 = 4
+)
+
 func LookupBulbs() ([]*Bulb, error) {
 	message := makeMessage()
 	message.tagged = true


### PR DESCRIPTION
I mentioned in #3 being interested in adding public constants to help with waveforms.

This PR adds them. I've cased them all upper case as that seems to be the style of the code. 

I'd happily change them to for example `WaveformSaw` which is more inline with standard Go formatting if you were interested.

```golang
bulb.SetWaveform(true, &golifx.HSBK{30000, 65000, 65000, 0}, 2000, 5, 0, golifx.WAVEFORM_SAW)
```